### PR TITLE
AutoCloseable JDBC Connection

### DIFF
--- a/src/main/java/ch/hearc/ig/guideresto/application/Main.java
+++ b/src/main/java/ch/hearc/ig/guideresto/application/Main.java
@@ -10,13 +10,13 @@ import java.util.Scanner;
 public class Main {
 
   public static void main(String[] args) {
-      var scanner = new Scanner(System.in);
-      var printStream = System.out;
-      var dbTransaction = new DBTransaction();
-      var daoFactory = new DAOFactory();
-      var restaurantService = new RestaurantService(dbTransaction, daoFactory);
-      var cli = new CLI(scanner, printStream, restaurantService);
-      cli.start();
+      try (var dbTransaction = new DBTransaction()) {
+          var scanner = new Scanner(System.in);
+          var printStream = System.out;
+          var daoFactory = new DAOFactory();
+          var restaurantService = new RestaurantService(dbTransaction, daoFactory);
+          var cli = new CLI(scanner, printStream, restaurantService);
+          cli.start();
+      }
   }
-
 }

--- a/src/main/java/ch/hearc/ig/guideresto/persistence/DBTransaction.java
+++ b/src/main/java/ch/hearc/ig/guideresto/persistence/DBTransaction.java
@@ -7,7 +7,7 @@ import java.util.function.Consumer;
 import java.sql.Connection;
 import java.util.function.Function;
 
-public class DBTransaction {
+public class DBTransaction implements AutoCloseable {
 
     private static final String DBURL = "jdbc:oracle:thin:@db.ig.he-arc.ch:1521:ens";
     private static final String DBUSER = "romain_jysch";
@@ -26,14 +26,6 @@ public class DBTransaction {
             return cnn;
         } catch (SQLException exOpenConnection) {
             throw new RuntimeException(exOpenConnection);
-        }
-    }
-
-    public void closeConnection() {
-        try {
-            connection.close();
-        } catch (SQLException exCloseConnection) {
-            throw new RuntimeException(exCloseConnection);
         }
     }
 
@@ -66,4 +58,12 @@ public class DBTransaction {
         }
     }
 
+    @Override
+    public void close() {
+        try {
+            connection.close();
+        } catch (SQLException exCloseConnection) {
+            throw new RuntimeException(exCloseConnection);
+        }
+    }
 }

--- a/src/main/java/ch/hearc/ig/guideresto/presentation/CLI.java
+++ b/src/main/java/ch/hearc/ig/guideresto/presentation/CLI.java
@@ -74,7 +74,6 @@ public class CLI {
         addNewRestaurant();
         break;
       case 0:
-        restaurantService.closeConnection();
         println("Au revoir !");
         break;
       default:

--- a/src/main/java/ch/hearc/ig/guideresto/services/RestaurantService.java
+++ b/src/main/java/ch/hearc/ig/guideresto/services/RestaurantService.java
@@ -66,9 +66,4 @@ public class RestaurantService {
     public void updateRestaurant(Restaurant restaurant) {
         dbTransaction.consumerTransaction(connection -> daoFactory.getDaoRestaurant().update(connection, restaurant));
     }
-
-    public void closeConnection() {
-        dbTransaction.closeConnection();
-    }
-
 }


### PR DESCRIPTION
Ouvrir la connection JDBC lors de l'initialisation de la base de données est une bonne idée en soit (uniquement dans un contexte __MONO-UTILISATEUR__ comme c'est le cas dans notre application).
Toutefois, ce n'est pas un cas d'utilisation de ton application, de ce fait, l'appel de fermeture de `DBTransaction` ne devrait pas se faire via un service par un appel de la CLI.

`DBTransaction` est un simple composant que tu souhaites pouvoir fermer à la fin de ton application.
Comme les `Connection`, les `PreparedStatement` ou les `ResultSet`, tu peux utiliser `try-with-resources` dès lors que la classe implémente l'interface `AutoCloseable`.